### PR TITLE
Fix ad-hoc Tauri release notarization

### DIFF
--- a/scripts/build-tauri.sh
+++ b/scripts/build-tauri.sh
@@ -98,6 +98,10 @@ if [[ "$APPLE_SIGNING_IDENTITY" == "Developer ID Application:"* ]]; then
   : "${APPLE_ID:?APPLE_ID is required for notarization}"
   : "${APPLE_PASSWORD:?APPLE_PASSWORD is required for notarization}"
   : "${APPLE_TEAM_ID:?APPLE_TEAM_ID is required for notarization}"
+else
+  # Tauri enables notarization when these variables merely exist, even if the
+  # GitHub secrets expanded to empty strings. Keep the ad-hoc path truly local.
+  unset APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID
 fi
 
 echo ">> signing bundled native dependencies with $APPLE_SIGNING_IDENTITY"


### PR DESCRIPTION
## Fix

Unset Apple notarization environment variables for ad-hoc macOS builds. GitHub exposes missing secrets as empty environment variables, and Tauri treats their presence as a request to notarize.

This prevents the failed `Team ID must be at least 3 characters` notarization attempt while retaining ad-hoc code signing.

## Validation

- `bash -n scripts/build-tauri.sh`
- Failure reproduced and identified from the `v0.1.2` release job log.
