### PR TITLE
fix: create harness home dir before spawning node sidecar

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -117,9 +117,8 @@ fn spawn_harness() -> Result<Child, String> {
     // to surface as a setup error -> tauri panic -> abort() (panic = "abort"
     // in the release profile), so create the directory (and any missing
     // parents) up front so a missing SPIKE_HOME/HOME cannot abort startup.
-    std::fs::create_dir_all(&home).map_err(|error| {
-        format!("failed to create harness home directory {home}: {error}")
-    })?;
+    std::fs::create_dir_all(&home)
+        .map_err(|error| format!("failed to create harness home directory {home}: {error}"))?;
 
     println!(
         "[dsh] node={} script={} home={}",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -112,6 +112,15 @@ fn spawn_harness() -> Result<Child, String> {
         .map(|value| format!("{value}/.dsh"))
         .unwrap_or_else(|_| env::var("DSH_HOME").unwrap_or_else(|_| format!("{home}/.dsh")));
 
+    // The harness is spawned with `current_dir(home)`, and macOS refuses to
+    // start a child whose working directory does not exist (ENOENT). That used
+    // to surface as a setup error -> tauri panic -> abort() (panic = "abort"
+    // in the release profile), so create the directory (and any missing
+    // parents) up front so a missing SPIKE_HOME/HOME cannot abort startup.
+    std::fs::create_dir_all(&home).map_err(|error| {
+        format!("failed to create harness home directory {home}: {error}")
+    })?;
+
     println!(
         "[dsh] node={} script={} home={}",
         node.display(),


### PR DESCRIPTION
## Summary

Fixes a launch-time SIGABRT (crash report: `abort()` inside the `NSApplicationDidFinishLaunching` observer).

## Root cause

- The app spawns the bundled Node sidecar with `current_dir(home)`, where `home` comes from `SPIKE_HOME` (fallback `HOME`).
- On macOS, spawning a child whose working directory does not exist fails with `ENOENT`.
- That error propagates out of the tauri setup hook, which panics with `Failed to setup app` (`tauri-2.11.5/src/app.rs:1425`).
- The release profile sets `panic = "abort"`, so the panic becomes a bare `abort()` / SIGABRT at launch — no readable error, no unwinding.

## Fix

In `spawn_harness()`, call `std::fs::create_dir_all(&home)` (creating missing parents) before spawning the sidecar, so a missing `SPIKE_HOME`/`HOME` cannot abort startup. Failures now surface as a readable error instead of a bare abort.

## Verification

- `cargo check` and `cargo test` pass.
- End-to-end: launched the app with `SPIKE_HOME` pointing at a nonexistent directory — it created the directory, spawned the node sidecar, and reached `harness ready`, no abort.
