### PR TITLE
fix: bootstrap Tauri launcher sidecars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepseek-harness-desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-desktop",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis-plugin-group": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-harness-desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Compact unofficial desktop host for DeepSeek Harness, powered by Tauri on macOS",
   "private": true,
   "license": "MIT",

--- a/scripts/build-tauri.sh
+++ b/scripts/build-tauri.sh
@@ -121,6 +121,15 @@ while IFS= read -r -d '' native_file; do
 done < <(find node_modules -type f \( -name '*.node' -o -name '*.dylib' -o -perm -111 \) -print0)
 echo "   signed $NATIVE_SIGNATURES native files"
 
+# Tauri validates every externalBin path from build.rs, including when Cargo is
+# only building the dsh launcher itself. Seed the two launcher paths with the
+# same-architecture Node sidecar to break that bootstrap cycle; the real CLI
+# binary replaces both placeholders immediately after Cargo finishes.
+for CLI_SIDECAR_NAME in dsh pnpm; do
+  cp "$SIDECAR" "src-tauri/binaries/${CLI_SIDECAR_NAME}-${TRIPLE}"
+  chmod +x "src-tauri/binaries/${CLI_SIDECAR_NAME}-${TRIPLE}"
+done
+
 echo ">> building bundled dsh command launcher"
 (
   cd src-tauri

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "libc",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 default-run = "deepseek-harness-desktop"
 description = "Tauri shell that boots @deepseek-ai/dsh web and shows it in the system webview"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek Harness Desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.chokwinlee.deepseek-harness-desktop",
   "build": {
     "frontendDist": "./ui"

--- a/test/plugin-ui.test.ts
+++ b/test/plugin-ui.test.ts
@@ -64,6 +64,11 @@ test('ships a dedicated CLI launcher instead of the relocated npm bin file', asy
   assert.deepEqual(tauri.bundle.externalBin, ['binaries/node', 'binaries/dsh', 'binaries/pnpm'])
   assert.doesNotMatch(build, /cp .*Contents\/MacOS\/(?:dsh|pnpm)/)
   assert.doesNotMatch(build, /codesign[\s\S]+Contents\/MacOS\/(?:dsh|pnpm)/)
+  const bootstrap = build.indexOf('for CLI_SIDECAR_NAME in dsh pnpm')
+  const compile = build.indexOf('cargo build --release --target "$TRIPLE" --bin dsh')
+  const replace = build.indexOf('install -m 755 "$CLI_BINARY" "src-tauri/binaries/dsh-${TRIPLE}"')
+  assert.ok(bootstrap >= 0 && bootstrap < compile)
+  assert.ok(compile < replace)
 })
 
 test('runs desktop pnpm operations without an interactive terminal', async () => {


### PR DESCRIPTION
## Summary

- seed the new `dsh` and `pnpm` externalBin paths before Cargo compiles the launcher
- replace both temporary sidecars with the real CLI binary before the Tauri signing/bundling stage
- add an ordering regression test
- bump the desktop version to `0.1.6`

## Root cause

The `v0.1.5` release runner started from a clean checkout. `cargo build --bin dsh` runs Tauri's build script, which validates every configured external binary before the `dsh` binary exists. The build therefore failed with:

```
resource path binaries/dsh-aarch64-apple-darwin doesn't exist
```

Local builds had generated sidecar files from earlier runs, so the clean-runner-only bootstrap cycle was initially hidden.

## Fix

The build script uses the already downloaded, same-architecture Node sidecar as a temporary seed for the two launcher paths. Immediately after the launcher build completes, both placeholders are overwritten with the real `dsh` CLI binary. Tauri then signs and bundles only the real final files.

## Validation

- removed the generated arm64 `dsh` and `pnpm` sidecars locally, then completed a fresh `npm run build:mac -- arm64`
- `npm test` — 18 tests passed
- `cargo test --locked --manifest-path src-tauri/Cargo.toml` — 11 tests passed
- `cargo clippy --locked --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `npm run verify:tauri` — native modules, pnpm, bundled DSH, plugin add/remove, HTTP readiness, Settings extension, and child cleanup passed
- `npm run check:release-size -- --platform mac` — 0.1.6 DMG and ZIP remain within budget

Failed release evidence: https://github.com/chokwinlee/deepseek-harness-desktop/actions/runs/31898664527
