### PR TITLE
Fix title bar window dragging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepseek-harness-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-desktop",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis-plugin-group": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-harness-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Compact unofficial desktop host for DeepSeek Harness, powered by Tauri on macOS",
   "private": true,
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-desktop"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libc",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-desktop"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 default-run = "deepseek-harness-desktop"
 description = "Tauri shell that boots @deepseek-ai/dsh web and shows it in the system webview"

--- a/src-tauri/capabilities/main-window-drag.json
+++ b/src-tauri/capabilities/main-window-drag.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-window-drag",
+  "description": "Allow the Desktop title bar to move its own main window.",
+  "windows": ["main"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*"]
+  },
+  "permissions": ["core:window:allow-start-dragging"]
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DeepSeek Harness Desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.chokwinlee.deepseek-harness-desktop",
   "build": {
     "frontendDist": "./ui"

--- a/src/usage-meter.js
+++ b/src/usage-meter.js
@@ -564,9 +564,9 @@
     style.dataset.dshUsageMeter = 'true'
     style.textContent = `
       body.dsh-native-titlebar-overlay { box-sizing: border-box !important; padding-top: 32px !important; }
-      .dsh-usage-meter { --meter-bg: #f6f7f9; --meter-layer: #fff; --meter-subtle: #f2f4f7; --meter-text: #22252b; --meter-muted: #66707c; --meter-border: rgba(20,26,35,.14); --meter-accent: #3b6ff5; position: fixed; z-index: 2147483646; top: 0; left: 0; right: 0; height: 32px; display: flex; justify-content: center; color: var(--dsw-alias-fg-default,var(--meter-text)); font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; font-size: 11px; line-height: 1; text-rendering: optimizeLegibility; -webkit-app-region: no-drag; pointer-events: none; }
+      .dsh-usage-meter { --meter-bg: #f6f7f9; --meter-layer: #fff; --meter-subtle: #f2f4f7; --meter-text: #22252b; --meter-muted: #66707c; --meter-border: rgba(20,26,35,.14); --meter-accent: #3b6ff5; position: fixed; z-index: 2147483646; top: 0; left: 0; right: 0; height: 32px; display: flex; justify-content: center; color: var(--dsw-alias-fg-default,var(--meter-text)); font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; font-size: 11px; line-height: 1; text-rendering: optimizeLegibility; -webkit-app-region: drag; app-region: drag; pointer-events: auto; user-select: none; -webkit-user-select: none; }
       body[data-ds-dark-theme] .dsh-usage-meter { --meter-bg: #24272d; --meter-layer: #202329; --meter-subtle: #292d34; --meter-text: #f1f3f6; --meter-muted: #aeb4bf; --meter-border: rgba(255,255,255,.14); --meter-accent: #7d9cff; }
-      .dsh-usage-summary { box-sizing: border-box; max-width: calc(100vw - 96px); height: 22px; margin-top: 5px; padding: 0 10px; display: flex; align-items: center; gap: 8px; overflow: hidden; border: 1px solid var(--meter-border); border-radius: 8px; color: inherit; background: var(--meter-bg); box-shadow: 0 1px 0 rgba(255,255,255,.12) inset; cursor: default; white-space: nowrap; font: inherit; font-weight: 500; letter-spacing: .01em; pointer-events: auto; }
+      .dsh-usage-summary { box-sizing: border-box; max-width: calc(100vw - 96px); height: 22px; margin-top: 5px; padding: 0 10px; display: flex; align-items: center; gap: 8px; overflow: hidden; border: 1px solid var(--meter-border); border-radius: 8px; color: inherit; background: var(--meter-bg); box-shadow: 0 1px 0 rgba(255,255,255,.12) inset; cursor: default; white-space: nowrap; font: inherit; font-weight: 500; letter-spacing: .01em; -webkit-app-region: no-drag; app-region: no-drag; pointer-events: auto; }
       .dsh-usage-summary:hover, .dsh-usage-summary[aria-expanded="true"] { border-color: color-mix(in srgb,var(--meter-accent) 42%,var(--meter-border)); background: var(--meter-layer); }
       .dsh-usage-summary:focus-visible { outline: 2px solid color-mix(in srgb,var(--meter-accent) 58%,transparent); outline-offset: 1px; }
       .dsh-usage-summary small { color: var(--meter-muted); font-size: 9px; }
@@ -580,7 +580,7 @@
       .dsh-usage-live i.is-running { background: #32b36b; box-shadow: 0 0 0 2px color-mix(in srgb,#32b36b 16%,transparent); }
       .dsh-usage-pulse { width: 6px; height: 6px; border-radius: 50%; background: var(--meter-accent); animation: dsh-usage-pulse 1.25s ease-in-out infinite; }
       @keyframes dsh-usage-pulse { 50% { opacity: .3; transform: scale(.75); } }
-      .dsh-usage-popover { position: absolute; top: 34px; left: calc(50% - 174px); width: 348px; box-sizing: border-box; padding: 6px; border: 1px solid var(--meter-border); border-radius: 12px; background: var(--meter-layer); box-shadow: 0 12px 36px rgba(10,16,28,.15),0 2px 7px rgba(10,16,28,.07); opacity: 0; visibility: hidden; pointer-events: none; transition: opacity 130ms ease,visibility 130ms; color: inherit; font-size: 11px; line-height: 1.3; }
+      .dsh-usage-popover { position: absolute; top: 34px; left: calc(50% - 174px); width: 348px; box-sizing: border-box; padding: 6px; border: 1px solid var(--meter-border); border-radius: 12px; background: var(--meter-layer); box-shadow: 0 12px 36px rgba(10,16,28,.15),0 2px 7px rgba(10,16,28,.07); opacity: 0; visibility: hidden; -webkit-app-region: no-drag; app-region: no-drag; pointer-events: none; transition: opacity 130ms ease,visibility 130ms; color: inherit; font-size: 11px; line-height: 1.3; }
       .dsh-usage-popover[data-open="true"] { opacity: 1; visibility: visible; pointer-events: auto; }
       .dsh-usage-popover-head { display: grid; grid-template-columns: 1.2fr .8fr; overflow: hidden; border-radius: 8px; background: var(--meter-subtle); box-shadow: 0 0 0 1px var(--meter-border) inset; }
       .dsh-usage-popover-head > div { display: flex; align-items: baseline; justify-content: space-between; padding: 8px 10px; }
@@ -617,6 +617,7 @@
     document.body.classList.add('dsh-native-titlebar-overlay')
     host = document.createElement('div')
     host.className = 'dsh-usage-meter'
+    host.setAttribute('data-tauri-drag-region', '')
     host.innerHTML = `
       <button class="dsh-usage-summary" type="button" aria-haspopup="dialog" aria-expanded="false">
         <span class="dsh-usage-pulse"></span><span>${t.loading}</span>

--- a/test/usage-meter.test.ts
+++ b/test/usage-meter.test.ts
@@ -128,3 +128,20 @@ test('keeps unmatched models unpriced and sums authoritative running-session thr
   assert.doesNotMatch(source, /未匹配模型不会按 0 元计算/)
   assert.doesNotMatch(source, /backdrop-filter/)
 })
+
+test('keeps the title-bar background draggable without swallowing usage controls', async () => {
+  const { source } = await loadUsageMeter()
+  const capability = JSON.parse(await readFile(
+    join(process.cwd(), 'src-tauri', 'capabilities', 'main-window-drag.json'),
+    'utf8',
+  ))
+
+  assert.match(source, /host\.setAttribute\('data-tauri-drag-region', ''\)/)
+  assert.match(source, /\.dsh-usage-meter \{[^}]*-webkit-app-region: drag;[^}]*pointer-events: auto;/)
+  assert.match(source, /\.dsh-usage-summary \{[^}]*-webkit-app-region: no-drag;[^}]*pointer-events: auto;/)
+  assert.match(source, /\.dsh-usage-popover \{[^}]*-webkit-app-region: no-drag;[^}]*pointer-events: none;/)
+  assert.doesNotMatch(source, /\.dsh-usage-meter \{[^}]*-webkit-app-region: no-drag;/)
+  assert.deepEqual(capability.windows, ['main'])
+  assert.deepEqual(capability.remote.urls, ['http://127.0.0.1:*'])
+  assert.deepEqual(capability.permissions, ['core:window:allow-start-dragging'])
+})


### PR DESCRIPTION
## What changed

- restore the 32px usage-meter background as a Tauri drag region
- keep the usage summary button and popover interactive and non-draggable
- grant only the main window on loopback Harness origins permission to start native dragging
- add regression coverage and bump the desktop release version to 0.2.1

## Root cause

The usage overlay covered the full native title-bar area while declaring the root as non-draggable. After restoring the drag marker, Tauri 2 also required an explicit `core:window:allow-start-dragging` capability for the random loopback origin.

## Impact

Users can drag the macOS window from blank title-bar space again, while the usage control still opens normally.

## Validation

- `npm test` — 31 passed
- `cargo test --manifest-path src-tauri/Cargo.toml` — 14 passed
- `npm run check:version -- v0.2.1`
- native macOS acceptance: window moved exactly +160,+100 from a synthetic drag; usage button opened without moving the window
